### PR TITLE
Update LaTeX headings detection

### DIFF
--- a/lib/latex-model.js
+++ b/lib/latex-model.js
@@ -2,12 +2,15 @@
 import AbstractModel from './abstract-model';
 
 // could just generate these...
-const H1_REGEX = /(\\section){(.*)}/g;
-const H2_REGEX = /(\\subsection){(.*)}/g;
-const H3_REGEX = /(\\subsubsection){(.*)}/g;
-const H4_REGEX = /(\\subsubsubsection){(.*)}/g;
+const H1_REGEX = /^(\\part\*?){([^}]*)/g;
+const H2_REGEX = /^(\\chapter\*?){([^}]*)/g;
+const H3_REGEX = /^(\\section\*?){([^}]*)/g;
+const H4_REGEX = /^(\\subsection\*?){([^}]*)/g;
+const H5_REGEX = /^(\\subsubsection\*?){([^}]*)/g;
+const H6_REGEX = /^(\\paragraph\*?){([^}]*)/g;
+const H7_REGEX = /^(\\subparagraph\*?){([^}]*)/g;
 
-const HEADING_REGEX = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX];
+const HEADING_REGEX = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX, H5_REGEX, H6_REGEX, H7_REGEX];
 
 export default class LatexModel extends AbstractModel {
   constructor(editorOrBuffer) {


### PR DESCRIPTION
Few fixes to better analyse LaTeX document headings:
1. Updated document structure, according to [wiki](https://en.wikibooks.org/wiki/LaTeX/Document_Structure#Sectioning_commands)
2. Added detection of starred versions of headings.
3. Added rule for the "\XXX" part to be the first thing on a line --- previous version was not proof for, e.g., commenting out the line.
4. Added rule to save only the string of a heading name up to the first "}" sign --- previous version tend to expand the name if more commands were on the same line.