### PR TITLE
Add support for LaTeX Beamer frames

### DIFF
--- a/lib/document-outline.js
+++ b/lib/document-outline.js
@@ -11,11 +11,12 @@ import {scopeIncludesOne} from './util';
 let MarkdownModelsForEditors = new WeakMap();
 let SubscriptionsForEditors = new WeakMap();
 
-const supportedScopes = ['source.gfm', 'text.md', 'text.tex.latex'];
+const supportedScopes = ['source.gfm', 'text.md', 'text.tex.latex', 'text.tex.latex.beamer'];
 const modelClassForScopes = {
   'source.gfm': MarkdownModel,
   'text.md': MarkdownModel,
-  'text.tex.latex': LatexModel
+  'text.tex.latex': LatexModel,
+  'text.tex.latex.beamer': LatexModel
 };
 
 // TODO: Decide whether highlight should follow scrolling or cursor position

--- a/lib/latex-model.js
+++ b/lib/latex-model.js
@@ -6,7 +6,7 @@ const H2_REGEX = /^(\\chapter\*?){([^}]*)/;
 const H3_REGEX = /^(\\section\*?){([^}]*)/;
 const H4_REGEX = /^(\\subsection\*?){([^}]*)/;
 const H5_REGEX = /^(\\subsubsection\*?){([^}]*)/;
-const H6_REGEX = /^(\\paragraph\*?){([^}]*)/;
+const H6_REGEX = /^(\\paragraph\*?){([^}]*)|^(\\begin{frame})(?:\[.*\])*(?:\n*\t*\\frametitle)?{([^}]*)/;
 const H7_REGEX = /^(\\subparagraph\*?){([^}]*)/;
 
 const HEADING_REGEXES = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX, H5_REGEX, H6_REGEX, H7_REGEX];
@@ -35,7 +35,12 @@ export default class LatexModel extends AbstractModel {
       let subresult = regex.exec(heading);
       level += 1;
       if (subresult) {
-        label = subresult[2];
+        if (subresult.length === 3) {
+          label = subresult[2];
+        }
+        else { // matched \begin{frame}
+          label = subresult[4];
+        }
         break;
       }
     }


### PR DESCRIPTION
* changed the `H6_REGEX` to also catch `\begin{frame}` and its many forms