### PR TITLE
Dirty hack to support for Setext style headers in markdown

### DIFF
--- a/lib/markdown-model.js
+++ b/lib/markdown-model.js
@@ -11,7 +11,8 @@ const H6_REGEX = /(^######)[^#](.*)/g;
 const H7_REGEX = /(^######)[^#](.*)/g;
 
 // const HEADING_REGEX = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX, H5_REGEX, H6_REGEX, H7_REGEX];
-const HEADING_REGEX = /(^#+)[^#](.*)/g;
+// const HEADING_REGEX = /(^#+)[^#](.*)/g;
+const HEADING_REGEX = /(^#+)[^#](.*)#*\n\n|(^[^\n]+)\n(=+|-+)\n/g;
 
 export default class MarkdownModel extends AbstractModel {
   constructor(editorOrBuffer) {
@@ -19,10 +20,17 @@ export default class MarkdownModel extends AbstractModel {
   }
 
   getRegexData(scanResult) {
-    return {
-      level: scanResult.match[1].length,
-      label: scanResult.match[2]
-    };
+    if (scanResult.match[1]) {
+      return {
+	level: scanResult.match[1].length,
+	label: scanResult.match[2]
+      };
+    } else {
+      return {
+	level: scanResult.match[4].substr(0, 1) == '=' ? 1 : 2,
+	label: scanResult.match[3]
+      };
+    }
   }
 
 }


### PR DESCRIPTION
support Setext style headers in markdown.

I change ATX-style header regex requre bank line after header,
to distinguish shell command or comment line in text literal block.
Markdown does not need blank line after ATX-style header,
but this change is reasonable for outline,
because it makes these literal lines are not appeared in outline.
It may be better to switch according to the setting.