### PR TITLE
support knitr, workaround for slowdown

### DIFF
--- a/lib/document-outline.js
+++ b/lib/document-outline.js
@@ -12,15 +12,17 @@ import {scopeIncludesOne} from './util';
 let DocModelsForEditors = new WeakMap();
 let SubscriptionsForEditors = new WeakMap();
 
-const supportedScopes = ['source.gfm', 'text.md', 'text.tex.latex', 'text.tex.latex.beamer', 'text.restructuredtext'];
 const modelClassForScopes = {
   'source.gfm': MarkdownModel,
   'text.md': MarkdownModel,
   'text.tex.latex': LatexModel,
   'text.tex.latex.beamer': LatexModel,
+  'text.tex.latex.knitr': LatexModel,
   'text.knitr': LatexModel,
   'text.restructuredtext': ReStructuredTextModel
 };
+
+const supportedScopes = Object.keys(modelClassForScopes);
 
 // TODO: Decide whether highlight should follow scrolling or cursor position
 
@@ -73,7 +75,7 @@ export default {
       command: 'document-outline:toggle'
     }]});
 
-    this.subscriptions.add(atom.workspace.observeActivePaneItem(pane => {
+    this.subscriptions.add(atom.workspace.onDidStopChangingActivePaneItem(pane => {
       this.updateCurrentEditor(pane);
     }));
 


### PR DESCRIPTION
three minor additions:
- added scope text.tex.latex.knitr (used in [language-knitr](https://atom.io/packages/language-knitr)) to supported scopes (addition to #6)
- workaround for #9 by updating outline only once the user stopped typing (not after every keystroke)
- use keys from scope to model mapping to extract supported scopes