### PR TITLE
Moved support for Asciidoc from setext to atx style headers.

### DIFF
--- a/lib/asciidoc-model.js
+++ b/lib/asciidoc-model.js
@@ -1,7 +1,9 @@
 'use babel';
 import AbstractModel from './abstract-model';
 
-const HEADING_REGEX = /^(.+)\n([!-/:-@[-`{-~])\2+$/gm;
+// Atx style headers only. Setext headers are not supported
+// http://asciidoctor.org/docs/asciidoc-recommended-practices/#section-titles
+const HEADING_REGEX = /^(=={0,5}|#\#{0,5})[ \t]+(.+?)(?:[ \t]+\1)?$/gm;
 
 export default class AsciiDocModel extends AbstractModel {
   constructor(editorOrBuffer) {
@@ -11,7 +13,7 @@ export default class AsciiDocModel extends AbstractModel {
 
   getRegexData(scanResult) {
     let level = 1;
-    let c = scanResult[2].substr(0, 1);
+    let c = scanResult[1].length;
 
     // Sometimes sectionLevels not set. Shouldn't happen but cant be bother to figure out why it does
     if (this.sectionLevels === undefined) {
@@ -26,7 +28,7 @@ export default class AsciiDocModel extends AbstractModel {
     }
     return {
       level: level,
-      label: scanResult[1]
+      label: scanResult[2]
     };
   }
 

--- a/spec/asciidoc-model-spec.js
+++ b/spec/asciidoc-model-spec.js
@@ -6,8 +6,7 @@ import AsciiDocModel from '../lib/asciidoc-model';
 import path from 'path';
 import fs from 'fs';
 
-var testText = `The Article Title
-=================
+var testText = `= The Article Title
 Author's Name <authors@email.address>
 v1.0, 2003-12
 
@@ -21,8 +20,8 @@ index section titles are significant ('specialsections').
 
 :numbered!:
 [abstract]
-Example Abstract
-----------------
+== Example Abstract
+
 The optional abstract (one or more paragraphs) goes here.
 
 This document is an AsciiDoc article skeleton containing briefly
@@ -31,8 +30,8 @@ and footnotes.
 
 :numbered:
 
-The First Section
------------------
+== The First Section
+
 Article sections start at level 1 and can be nested up to four levels
 deep.
 footnote:[An example footnote.]
@@ -48,9 +47,9 @@ Note that multi-entry terms generate separate index entries.
 
 `;
 
-describe('ReStructuredTextModel', () => {
-  describe('when we run rst pass on a text buffer', () => {
-    it('should parse the rst text', () => {
+describe('AsciiDocTextModel', () => {
+  describe('when we run adoc pass on a text buffer', () => {
+    it('should parse the adoc text', () => {
       let buffer = new TextBuffer(testText);
 
       let model = new AsciiDocModel(buffer);
@@ -58,7 +57,7 @@ describe('ReStructuredTextModel', () => {
       expect(headings.length).toEqual(1);
       expect(headings[0].children.length).toEqual(2);
     });
-    it('should parse a rst file text', () => {
+    it('should parse an adoc file text', () => {
       let src = path.join(__dirname, "..", "spec", "test.adoc");
       // let src = 'atom://document-outline/spec/test.json';
 

--- a/spec/test.adoc
+++ b/spec/test.adoc
@@ -1,5 +1,4 @@
-The Article Title
-=================
+= The Article Title
 Author's Name <authors@email.address>
 v1.0, 2003-12
 
@@ -13,8 +12,8 @@ index section titles are significant ('specialsections').
 
 :numbered!:
 [abstract]
-Example Abstract
-----------------
+== Example Abstract
+
 The optional abstract (one or more paragraphs) goes here.
 
 This document is an AsciiDoc article skeleton containing briefly
@@ -22,9 +21,8 @@ annotated element placeholders plus a couple of example index entries
 and footnotes.
 
 :numbered:
+== The First Section
 
-The First Section
------------------
 Article sections start at level 1 and can be nested up to four levels
 deep.
 footnote:[An example footnote.]
@@ -60,16 +58,16 @@ Lorum ipum...
 ===============================================
 
 [[X1]]
-Sub-section with Anchor
-~~~~~~~~~~~~~~~~~~~~~~~
+=== Sub-section with Anchor
+
 Sub-section at level 2.
 
-A Nested Sub-section
-^^^^^^^^^^^^^^^^^^^^
+==== A Nested Sub-section
+
 Sub-section at level 3.
 
-Yet another nested Sub-section
-++++++++++++++++++++++++++++++
+===== Yet another nested Sub-section
+
 Sub-section at level 4.
 
 This is the maximum sub-section depth supported by the distributed
@@ -77,8 +75,8 @@ AsciiDoc configuration.
 footnote:[A second example footnote.]
 
 
-The Second Section
-------------------
+== The Second Section
+
 Article sections are at level 1 and can contain sub-sections nested up
 to four deep.
 
@@ -91,19 +89,19 @@ An example link to a bibliography entry <<taoup>>.
 :numbered!:
 
 [appendix]
-Example Appendix
-----------------
+== Example Appendix
+
 AsciiDoc article appendices are just just article sections with
 'specialsection' titles.
 
-Appendix Sub-section
-~~~~~~~~~~~~~~~~~~~~
+=== Appendix Sub-section
+
 Appendix sub-section at level 2.
 
 
 [bibliography]
-Example Bibliography
---------------------
+== Example Bibliography
+
 The bibliography list is a style of AsciiDoc bulleted list.
 
 [bibliography]
@@ -115,8 +113,8 @@ The bibliography list is a style of AsciiDoc bulleted list.
 
 
 [glossary]
-Example Glossary
-----------------
+== Example Glossary
+
 Glossaries are optional. Glossaries entries are an example of a style
 of AsciiDoc labeled lists.
 
@@ -130,8 +128,7 @@ A second glossary term::
 
 ifdef::backend-docbook[]
 [index]
-Example Index
--------------
+== Example Index
 ////////////////////////////////////////////////////////////////
 The index is normally left completely empty, it's contents being
 generated automatically by the DocBook toolchain.


### PR DESCRIPTION
Does involve breaking change to remove support from setext style headers and only support atx headers.

I tried to not to break the model but requesting it to handle two different types of headers seems to be difficult with the present AbstractModel (or more likely, beyond my Javascript ability).

Atx styles are the recommended way to write in Asciidoc (Asciidoctor is now the successor to Asciidoc which is deprecated and no longer under development), see here:
http://asciidoctor.org/docs/asciidoc-recommended-practices/#section-titles

Hopefully this is of some assistance.

Resolves #26.