### PR TITLE
Minor bugfix in the code that closed ranges

### DIFF
--- a/lib/abstract-model.js
+++ b/lib/abstract-model.js
@@ -83,8 +83,8 @@ export default class AbstractModel {
         stack.push(heading);
       } else if (heading.level === top.level) {
         // At equal level, we close the previous heading
-        top.range.end = heading.headingRange.start;
-        top.range.end.row -= 1;
+		// @CBenghi bugfix: copying reference followed by edit of row impacted the start of the following header also
+        top.range.end = new Point(heading.headingRange.start.row - 1, heading.headingRange.start.column);
         // Then get the parent
         top = stack.pop();
         top.children.push(heading);
@@ -93,13 +93,13 @@ export default class AbstractModel {
       } else if (top.level > heading.level) {
         // This starts a new section at a more important level
         // roll up the stack
-        top.range.end = heading.headingRange.start;
-        top.range.end.row -= 1;
+		// @CBenghi bugfix: copying reference followed by edit of row impacted the start of the following header also
+        top.range.end = new Point(heading.headingRange.start.row - 1, heading.headingRange.start.column);
         while (top) {
           top = stack.pop();
           // Close each range until we get to the suitable parent
-          top.range.end = heading.headingRange.start;
-          top.range.end.row -= 1;
+		  // @CBenghi bugfix: copying reference followed by edit of row impacted the start of the following header also
+          top.range.end = new Point(heading.headingRange.start.row - 1, heading.headingRange.start.column); 
           if (top.level < heading.level) {
             break;
           }

--- a/lib/document-outline-view.js
+++ b/lib/document-outline-view.js
@@ -1,16 +1,14 @@
 'use babel';
 
-import {Point, CompositeDisposable} from 'atom';
+import {Point} from 'atom';
 import {DocumentTree} from './tree-view';
 import {createElement} from './util';
 
 export default class DocumentOutlineView {
 
   constructor() {
-    this.subscriptions = new CompositeDisposable();
-    // Not sure why, but have to bind callback function explicitly
-    this.highlightSectionAtCursor = this.highlightSectionAtCursor.bind(this);
-    this.scrollToSectionAtCursor = this.scrollToSectionAtCursor.bind(this);
+	this.sub1 = null;
+	this.sub2 = null;
     this.element = createElement('div', {class: 'document-outline'});
 
     this.docTree = new DocumentTree();
@@ -45,7 +43,8 @@ export default class DocumentOutlineView {
 
   // Tear down any state and detach
   destroy() {
-    this.subscriptions.dispose();
+    this.sub1.dispose();
+    this.sub2.dispose();
     this.element.remove();
   }
 
@@ -68,13 +67,16 @@ export default class DocumentOutlineView {
     }
 
     // Clear existing events and re-subscribe to make sure we don't accumulate subscriptions
-    this.subscriptions.dispose();
+	if (this.sub1)
+		this.sub1.dispose();
+	if (this.sub2)
+		this.sub2.dispose();
 
     // NOTE: highlightSection is wierdly resource intensive.
     if (atom.config.get("document-outline.highlightCurrentSection")) {
       this.highlightSectionAtCursor(editor.getCursorBufferPosition());
-      this.subscriptions.add(editor.onDidChangeCursorPosition(event => {
-        // Highligh section in outline only if buffor position change
+      this.sub1 = (editor.onDidChangeCursorPosition(event => {
+        // Highligh section in outline only if buffer position change
         if (event.oldBufferPosition.row !== event.newBufferPosition.row) {
           this.highlightSectionAtCursor(event.cursor.getBufferPosition());
         }
@@ -83,7 +85,7 @@ export default class DocumentOutlineView {
 
     if (atom.config.get("document-outline.autoScrollOutline")) {
       this.scrollToSectionAtCursor(editor.getCursorBufferPosition());
-      this.subscriptions.add(editor.onDidChangeCursorPosition(event => {
+      this.sub2 = (editor.onDidChangeCursorPosition(event => {
         if (event.oldBufferPosition.row !== event.newBufferPosition.row) {
           this.scrollToSectionAtCursor(event.cursor.getBufferPosition());
         }

--- a/lib/document-outline-view.js
+++ b/lib/document-outline-view.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import {CompositeDisposable} from 'atom';
+import {Point, CompositeDisposable} from 'atom';
 import {DocumentTree} from './tree-view';
 import {createElement} from './util';
 
@@ -61,8 +61,8 @@ export default class DocumentOutlineView {
     for (let label of this.docTree.querySelectorAll('span.tree-item-text')) {
       label.addEventListener('click', event => {
         let treeNode = event.target.parentNode;
-        let range = treeNode.range;
-        editor.scrollToBufferPosition(range.start, {center: true});
+        const pt = new Point(treeNode.range.start.row - 1, 0);
+        editor.scrollToBufferPosition(pt, {center: true});
         event.stopPropagation();
       });
     }


### PR DESCRIPTION
Hello @mangecoeur,
I've spotted a minor bug that resulted in inconsistent positioning of the selected header at the centre of the screen.
Copying the start position and then reducing its row for the end of the previous header resulted in both rows being reduced.

I've now fixed it by cloning the point coordinates instead.

Because it's in the abstract class it might have impacts on other formats, at the moment i'm only working with markdown, it should work with all formats, but I'm not sure.

Best,
Claudio