### PR TITLE
Update LaTeX Regex without \partial as a header

### DIFF
--- a/lib/latex-model.js
+++ b/lib/latex-model.js
@@ -3,13 +3,13 @@ import AbstractModel from './abstract-model';
 
 // Possible regex to exclude commented lines
 // ^(?:!%)*\s*
-const H1_REGEX = /(\\part\*?)\[?.*\]?{([^}]*)/;
-const H2_REGEX = /(\\chapter\*?)\[?.*\]?{([^}]*)/;
-const H3_REGEX = /(\\section|frametitle\*?)\[?.*\]?{([^}]*)/;
-const H4_REGEX = /(\\subsection|framesubtitle\*?)\[?.*\]?{([^}]*)/;
-const H5_REGEX = /(\\subsubsection\*?)\[?.*\]?{([^}]*)/;
-const H6_REGEX = /(\\paragraph\*?)\[?.*\]?{([^}]*)/;
-const H7_REGEX = /(\\subparagraph\*?)\[?.*\]?{([^}]*)/;
+const H1_REGEX = /(\\part\*?)(\[.*\])?{([^}]*)/;
+const H2_REGEX = /(\\chapter\*?)(\[.*\])?{([^}]*)/;
+const H3_REGEX = /(\\section|frametitle\*?)(\[.*\])?{([^}]*)/;
+const H4_REGEX = /(\\subsection|framesubtitle\*?)(\[.*\])?{([^}]*)/;
+const H5_REGEX = /(\\subsubsection\*?)(\[.*\])?{([^}]*)/;
+const H6_REGEX = /(\\paragraph\*?)(\[.*\])?{([^}]*)/;
+const H7_REGEX = /(\\subparagraph\*?)(\[.*\])?{([^}]*)/;
 
 const HEADING_REGEXES = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX, H5_REGEX, H6_REGEX, H7_REGEX];
 

--- a/spec/latex-model-spec.js
+++ b/spec/latex-model-spec.js
@@ -6,7 +6,8 @@ import LatexModel from '../lib/latex-model';
 import path from 'path';
 import fs from 'fs';
 
-var testText = `
+// Need String.raw to use literal backslash character.
+var testText = String.raw`
 \chapter{Introduction}
 
 This chapter's content...
@@ -53,8 +54,22 @@ pervenit, hic sensit, tellusAndros femineos miles feres fiat venis!
 
 `;
 
+var testPartialVsPart = String.raw`
+\part[filler text]{Part name}
+$\partial x$
+$\partial{x}$
+`;
+
 describe('LatexModel', () => {
   describe('when we run latex pass on a text buffer', () => {
+    it('should parse the latex text', () => {
+      let buffer = new TextBuffer(testText);
+
+      let model = new LatexModel(buffer);
+      let headings = model.parse();
+      expect(headings.length).toBeGreaterThan(0);
+      expect(headings[0].children.length).toBeGreaterThan(0);
+    });
     it('should parse a latex file text', () => {
       let src = path.join(__dirname, "..", "spec", "test.tex");
       // let src = 'atom://document-outline/spec/test.json';
@@ -67,6 +82,16 @@ describe('LatexModel', () => {
       expect(headings.length).toBeGreaterThan(0);
       expect(headings[0].children.length).toBeGreaterThan(0);
 
+    });
+  });
+  describe('when we run latex pass on a text buffer containing the \\partial command', () => {
+    it('should ignore any \\partial when creating headings', () => {
+      let buffer = new TextBuffer(testPartialVsPart);
+      let model = new LatexModel(buffer);
+      let headings = model.parse();
+
+      expect(headings.length).toEqual(1);
+      expect(headings[0].children.length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
Hi @mangecoeur,

Great Atom package!

I write a decent amount of math in LaTeX, and the `\partial` command (for partial derivatives) was getting flagged as a header because of the regex for the `\part` command, making the outline messy to the point of being almost useless (in this case, any equation in the text generates a H1 header, breaking all other structure).

This change updates the logic for the regexes for LaTeX headers, now requiring either `\headerHere[stuff...]{headerName` or `\headerhere{headerName` (matched square braces), rather than allowing extraneous text in-between. I added a quick test case for \part and \partial, just to be sure (and ran it against the current version to make sure the test broke). While I was in the test code, I noticed that `var testText` wasn't being used, so I added a test case that uses the text buffer instead of the file text, based on the existing test for AsciiDoc.