### PR TITLE
Add basic support for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Currently supports:
 - ReStructuredText
 - AsciiDoc
 - Knitr
+- Python
 
 ## Usage
 

--- a/lib/document-outline.js
+++ b/lib/document-outline.js
@@ -4,6 +4,7 @@ import MarkdownModel from './markdown-model';
 import LatexModel from './latex-model';
 import ReStructuredTextModel from './rst-model';
 import AsciiDocModel from './asciidoc-model';
+import PythonModel from './python-model';
 
 import DocumentOutlineView from './document-outline-view';
 import {CompositeDisposable} from 'atom';
@@ -17,7 +18,8 @@ const MODEL_CLASS_FOR_SCOPES = {
   'text.tex.latex.knitr': LatexModel,
   'text.knitr': LatexModel,
   'text.restructuredtext': ReStructuredTextModel,
-  'source.asciidoc': AsciiDocModel
+  'source.asciidoc': AsciiDocModel,
+  'source.python': PythonModel
 };
 
 const SUPPORTED_SCOPES = Object.keys(MODEL_CLASS_FOR_SCOPES);

--- a/lib/python-model.js
+++ b/lib/python-model.js
@@ -18,7 +18,6 @@ const HEADING_REGEX = new RegExp(COMBO_REGEX.slice(0, -1), 'gm');
 export default class PythonModel extends AbstractModel {
   constructor(editorOrBuffer) {
     super(editorOrBuffer, HEADING_REGEX);
-    this.maxDepth += 1;
   }
 
   getRegexData(scanResult) {

--- a/lib/python-model.js
+++ b/lib/python-model.js
@@ -1,0 +1,50 @@
+'use babel';
+import AbstractModel from './abstract-model';
+
+const CLASS_REGEX = /(class)\s+(\w+)\s*(:|\(([^\)]*))/;
+const DEF_REGEX = /(def)\s+(\w+)\s*\(([^\)]*)/;
+
+const HEADING_REGEXES = [CLASS_REGEX, DEF_REGEX];
+
+let COMBO_REGEX = '';
+for (let regex of HEADING_REGEXES) {
+  // Join the regexes together, adding wildcard to match whole line, which lets
+  // us detect '%' comment marks later
+  COMBO_REGEX = COMBO_REGEX + '(.*' + regex.source + ')|';
+}
+
+const HEADING_REGEX = new RegExp(COMBO_REGEX.slice(0, -1), 'gm');
+
+export default class PythonModel extends AbstractModel {
+  constructor(editorOrBuffer) {
+    super(editorOrBuffer, HEADING_REGEX);
+    this.maxDepth += 1;
+  }
+
+  getRegexData(scanResult) {
+    let level = 0;
+    let label = '';
+    let heading = scanResult[0];
+    heading = heading.trim();
+    // Skip result if line is commented out.
+    if (heading.startsWith("#")) {
+      return;
+    }
+
+    for (let regex of HEADING_REGEXES) {
+      level += 1;
+      if (level <= this.maxDepth) {
+        let subresult = regex.exec(heading);
+        if (subresult) {
+          label = subresult[2];
+          break;
+        }
+      }
+    }
+
+    return {
+      level: level,
+      label: label
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "knitr",
     "academic",
     "text",
-    "asciidoc"
+    "asciidoc",
+    "python"
   ],
   "repository": "https://github.com/mangecoeur/document-outline",
   "license": "GPL-3.0",

--- a/spec/python-model-spec.js
+++ b/spec/python-model-spec.js
@@ -1,0 +1,32 @@
+'use babel';
+/* eslint-env node, browser, jasmine */
+
+import {TextBuffer} from 'atom';
+import PythonModel from '../lib/python-model';
+import path from 'path';
+import fs from 'fs';
+
+var testText = `
+def fn1(self, something, some_class):
+  pass
+
+class T:
+  def fn2(self):
+    pass
+
+class asdf (object):
+  pass
+`;
+
+describe('PythonModel', () => {
+  describe('when we run python pass on a text buffer', () => {
+    it('should parse the python text', () => {
+      let buffer = new TextBuffer(testText);
+
+      let model = new PythonModel(buffer);
+      let headings = model.parse();
+      expect(headings.length).toEqual(3);
+      expect(headings[1].children.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Hello again @mangecoeur!

I know Python might be beyond the scope you want for this package, but it's useful for me to quickly jump between different functions. In theory, I know Python is flexible enough to allow for a class to be in a function to be in a class to be in a function... but this just handles the basic class > function.

Useful for me, but understand if you'd rather not get bogged down in it later.

~@eaott