### PR TITLE
Added support for file format 'API Blueprint'

### DIFF
--- a/lib/document-outline.js
+++ b/lib/document-outline.js
@@ -11,6 +11,7 @@ const {scopeIncludesOne} = require('./util');
 
 const MODEL_CLASS_FOR_SCOPES = {
   'source.gfm': MarkdownModel,
+  'text.html.markdown.source.gfm.apib': MarkdownModel,
   'text.md': MarkdownModel,
   'text.tex.latex': LatexModel,
   'text.tex.latex.beamer': LatexModel,


### PR DESCRIPTION
Hi. Your add-on is very useful for me. But now it has no support for file format 'API Blueprint' which I need (or maybe I just don't know how to enable it). And there is also very useful for me add-on [atom-language-api-blueprint](https://atom.io/packages/language-api-blueprint) for 'API Blueprint'. I don't know much about Atom yet, but I have found that this add-on adds some scope which can be described in your code and this change can enable outlining. So I suggest you my code improvement. Thanks for your work!