### PR TITLE
words and characters of section in title-attribute

### DIFF
--- a/lib/outline-tree.js
+++ b/lib/outline-tree.js
@@ -69,6 +69,14 @@ class OutlineTreeView {
     let iconClass = `icon ${this.icon}`;
     let itemClass = `list-nested-item list-selectable-item ${this.highlight}`;
     let itemId = `document-outline-${this.startRow}-${this.endRow}`;
+    const editor = atom.workspace.getActiveTextEditor();
+    let text = editor.getTextInBufferRange([[this.startRow -1,0],[this.endRow -1,0]]);
+    let title = ''
+    if (text) {
+        let wordcount = text.match(/\S+/g).length;
+        let charcount = text.length - 1;
+        title = wordcount + " W | " + charcount + " C";
+    }
 
     return <div class={itemClass}
     startrow={this.startRow} endrow={this.endRow}
@@ -77,7 +85,7 @@ class OutlineTreeView {
     ref="outlineElement"
     >
     <span class={iconClass} on={{click: this.toggleSubtree}}></span>
-    <span class="tree-item-text" on={{
+    <span class="tree-item-text" title={title} on={{
       click: this.didClick,
       dblclick: this.toggleSubtree}}>
     {this.plainText}</span>


### PR DESCRIPTION
Not sure if this is your coding style, but here's a small PR to display words and characters of sections in the html-title element so that it is displayed on hover. Feel free to adjust it to suit the logic of the program better! Hope you find it useful.

At the minute it's updated only when a the cursor changes lines, which is maybe not super responsive but sufficient.

![example](https://user-images.githubusercontent.com/19365355/36691775-1fffe3ce-1b2e-11e8-9419-cc3057c6d1c4.png)