### PR TITLE
Fixing issue #85

### DIFF
--- a/lib/rst-model.js
+++ b/lib/rst-model.js
@@ -1,6 +1,6 @@
 const {AbstractModel} = require('./abstract-model');
 
-const HEADING_REGEX = /^(.+)\n([!-/:-@[-`{-~])\2+$/gm;
+const HEADING_REGEX = /^(.+)\r?\n([!-/:-@[-`{-~])\2+$/gm;
 
 class ReStructuredTextModel extends AbstractModel {
   constructor(editorOrBuffer) {


### PR DESCRIPTION
Currently HEADING_REGEX supposes that the document has "linux-style" end of lines. Fixed in RST model to support CRLF.
All other models will need to be corrected thow (or find some way to solve it more globally in AbstractModel)