### PR TITLE
Minor fixes

### DIFF
--- a/lib/document-outline-view.js
+++ b/lib/document-outline-view.js
@@ -97,6 +97,7 @@ class DocumentOutlineView {
       let cursorPos = this.cursorPos;
       let range;
       let didFindDeepestItem = false;
+	  let matchId;
 
       // NOTE: getElementsByClassName + filter should be much faster thant
       // querySelectorAll on .list-nested-item.current
@@ -104,6 +105,10 @@ class DocumentOutlineView {
       Array.from(elements).map(el => {
         return el.classList.remove('current');
       });
+	  Array.from(elements).map(el => {
+        return el.children[1].classList.remove('currentTreeText');
+      });
+	  
 
       for (let item of this.getDepthFirstItems(this.outline)) {
         range = item.range;
@@ -117,10 +122,14 @@ class DocumentOutlineView {
               // without affecting parents or children
               foundElement.classList.add('current');
               didFindDeepestItem = true;
+			  matchId = foundElement.children[1].classList; // the leaf text
             }
           }
         }
       }
+	  if (matchId) {
+        matchId.add('currentTreeText');
+	  }
     }
   }
 

--- a/lib/document-outline-view.js
+++ b/lib/document-outline-view.js
@@ -2,6 +2,7 @@
 /** @jsx etch.dom */
 
 const etch = require('etch');
+const {Point} = require('atom');
 const {OutlineTreeView} = require('./outline-tree');
 
 class DocumentOutlineView {
@@ -94,7 +95,11 @@ class DocumentOutlineView {
 
   readAfterUpdate() {
     if (this.autoScroll && this.cursorPos) {
-      let cursorPos = this.cursorPos;
+	  // ranges of items are expressed with 1-based indices for row and always 1 as column
+	  // because cursorPos is 0 based we build a custom made point from the cursor for comparison.
+	  //
+      let cursorPos = new Point(this.cursorPos.row + 1, 1);
+	  
       let range;
       let didFindDeepestItem = false;
 	  let matchId;

--- a/styles/document-outline.less
+++ b/styles/document-outline.less
@@ -50,6 +50,10 @@
         // text-shadow: 1px 0px 0px @text-color;
       }
     }
+	
+	span.tree-item-text.currentTreeText { 
+		color: @text-color-selected;
+	}
 
     // used for constant indentation in tree hierarchy when compressing/expanding (@CBenghi)
 	  .icon {


### PR DESCRIPTION
Hi @mangecoeur,

I've a few minor changes to the library in two commits.
1) one enables the highlight of the selected tree item text (not of the children)
2) the second fixes the highlight of tree elements in the tree removing a problem between 0-based and 1-based indices between the cursor and content ranges.

I Hope you find this useful.
Best,
Claudio

